### PR TITLE
Implement atom, compare-and-set!, reset!, swap! and deref for atoms

### DIFF
--- a/src/clj/clojure/lang/atom.clj
+++ b/src/clj/clojure/lang/atom.clj
@@ -1,0 +1,47 @@
+(ns clojure.lang.atom
+  (:refer-clojure :only [apply defn defn- deftype let into])
+  (:require [clojure.lang.iatom                   :refer [IAtom -compare-and-set! -reset! -swap!]]
+            [clojure.lang.ideref                  :refer [IDeref]]
+            [clojure.lang.equivalence             :refer [=]]
+            [clojure.lang.platform.mutable-entity :as    ent]))
+
+(defn compare-and-set! [atm old-state new-state]
+  (-compare-and-set! atm old-state new-state))
+
+(defn reset! [atm new-state]
+  (-reset! atm new-state))
+
+(defn swap!
+  ([atm f] (-swap! atm f []))
+  ([atm f arg] (-swap! atm f [arg]))
+  ([atm f arg1 arg2] (-swap! atm f [arg1 arg2]))
+  ([atm f arg1 arg2 & args] (-swap! atm f (into [arg1 arg2] args))))
+
+(deftype Atom [-state]
+  IDeref
+  (-deref [this] (ent/get-entity -state))
+
+  IAtom
+  (-compare-and-set! [this old-state new-state]
+    (if (= (ent/get-entity -state) old-state)
+      (do
+        (ent/set-entity! -state new-state)
+        true)
+      false))
+
+  (-reset! [this new-state]
+    (do
+      (ent/set-entity! -state new-state)
+      new-state))
+
+  (-swap! [this f args]
+    (let [entity (ent/get-entity -state)
+          arg-list (into [entity] args)
+          updated-entity (apply f arg-list)]
+      (ent/set-entity! -state updated-entity)
+      updated-entity))
+
+  )
+
+(defn atom [state]
+  (Atom. (ent/make-mutable-entity state)))

--- a/src/clj/clojure/lang/deref.clj
+++ b/src/clj/clojure/lang/deref.clj
@@ -1,0 +1,6 @@
+(ns clojure.lang.deref
+  (:refer-clojure :only [defn])
+  (:require [clojure.lang.ideref :refer [-deref]]))
+
+(defn deref [obj]
+  (-deref obj))

--- a/src/clj/clojure/lang/iatom.clj
+++ b/src/clj/clojure/lang/iatom.clj
@@ -1,0 +1,7 @@
+(ns clojure.lang.iatom
+  (:refer-clojure :refer [defprotocol]))
+
+(defprotocol IAtom
+  (-compare-and-set! [this old-state new-state])
+  (-reset! [this new-state])
+  (-swap! [this f args]))

--- a/src/clj/clojure/lang/ideref.clj
+++ b/src/clj/clojure/lang/ideref.clj
@@ -1,0 +1,5 @@
+(ns clojure.lang.ideref
+  (:refer-clojure :only [defprotocol]))
+
+(defprotocol IDeref
+  (-deref [this]))

--- a/src/jvm/clojure/lang/platform/imutable_entity.clj
+++ b/src/jvm/clojure/lang/platform/imutable_entity.clj
@@ -1,0 +1,6 @@
+(ns clojure.lang.platform.imutable-entity
+  (:refer-clojure :only [defprotocol]))
+
+(defprotocol IMutableEntity
+  (-get [this])
+  (-set [this entity]))

--- a/src/jvm/clojure/lang/platform/mutable_entity.clj
+++ b/src/jvm/clojure/lang/platform/mutable_entity.clj
@@ -1,0 +1,23 @@
+(ns clojure.lang.platform.mutable-entity
+  (:refer-clojure :only [defn deftype let])
+  (:require [clojure.lang.platform.imutable-entity :refer [IMutableEntity -get -set]]
+            [clojure.lang.platform.mutable-array   :as    arr]))
+
+(defn get-entity [entity]
+  (-get entity))
+
+(defn set-entity! [entity new-value]
+  (-set entity new-value))
+
+(deftype MutableEntity [-entity-arr]
+  IMutableEntity
+  (-get [this]
+    (arr/array-get -entity-arr 0))
+
+  (-set [this -updated-entity]
+    (arr/array-set! -entity-arr 0 -updated-entity)))
+
+(defn make-mutable-entity [value]
+  (let [mutable-array (arr/make-array 1)]
+    (arr/array-set! mutable-array 0 value)
+    (MutableEntity. mutable-array)))

--- a/test/clj/clojure/lang/atom_test.clj
+++ b/test/clj/clojure/lang/atom_test.clj
@@ -1,0 +1,50 @@
+(ns clojure.lang.atom-test
+  (:refer-clojure :only [and first let -])
+  (:require [clojure.test             :refer :all]
+            [clojure.lang.atom        :refer :all]
+            [clojure.lang.deref       :refer [deref]]
+            [clojure.lang.equivalence :refer [not =]]))
+
+(deftest atom-test
+  (testing "creates an atom which can be dereferenced"
+    (let [atm (atom "atm")]
+      (is (= "atm" (deref atm)))))
+
+  (testing "allows an atom's state to be set if the current state's comparison succeeds"
+    (let [atm     (atom "atm")
+          success (compare-and-set! atm "atm" "new atm")]
+      (is (and success
+               (= "new atm" (deref atm))))))
+
+  (testing "does not allow an atom's state to be set if the current state's comparison fails"
+    (let [atm     (atom "atm")
+          success (compare-and-set! atm "not atm" "new atm")]
+      (is (and (not success)
+               (= "atm" (deref atm))))))
+
+  (testing "reset! the atom's state"
+    (let [atm (atom "atm")]
+      (is (and (= "update" (reset! atm "update"))
+               (= "update" (deref atm))))))
+
+  (testing "swap! the atom's state with a function"
+    (let [atm (atom [1, 2])]
+      (is (and (= 1 (swap! atm first))
+               (= 1 (deref atm))))))
+
+  (testing "swap! the atom's state with a function and an argument"
+    (let [atm (atom 7)]
+      (is (and (= 6 (swap! atm - 1))
+               (= 6 (deref atm))))))
+
+  (testing "swap! the atom's state with a function and two arguments"
+    (let [atm (atom 7)]
+      (is (and (= 4 (swap! atm - 1 2))
+               (= 4 (deref atm))))))
+
+  (testing "swap! the atom's state with a function and arbitrary arguments"
+    (let [atm (atom 7)]
+      (is (and (= -3 (swap! atm - 1 2 3 4))
+               (= -3 (deref atm))))))
+
+  )

--- a/test/jvm/clojure/lang/platform/mutable_entity_test.clj
+++ b/test/jvm/clojure/lang/platform/mutable_entity_test.clj
@@ -1,0 +1,15 @@
+(ns clojure.lang.platform.mutable-entity-test
+  (:refer-clojure :only [let =])
+  (:require [clojure.test                         :refer :all]
+            [clojure.lang.platform.mutable-entity :refer :all]))
+
+(deftest mutable-entity-test
+  (testing "the entity is set in the constructor"
+    (let [ent (make-mutable-entity "ent")]
+      (is (= "ent" (get-entity ent)))))
+
+  (testing "the entity can be set"
+    (let [ent (make-mutable-entity "first")]
+      (set-entity! ent "second")
+      (is (= "second" (get-entity ent)))))
+  )


### PR DESCRIPTION
MutableEntity is clever, but I couldn't think of a way to make it work without writing a java class. I focused instead on making the interface get and set which will make it easy to implement for all platforms.

The atom specific functions were pulled out into IAtom, which is covered by this pull request. Following this, IRef will need implemented, which will force the addition of metadata to atom and allow ref to be easily implemented.
