### PR TITLE
Implement get/3, allowing for user specified not-found

### DIFF
--- a/src/clj/clojure/lang/ipersistent_map.clj
+++ b/src/clj/clojure/lang/ipersistent_map.clj
@@ -5,5 +5,5 @@
   (-assoc     [this k v])
   (-contains? [this k])
   (-dissoc    [this k])
-  (-lookup    [this k])
+  (-lookup    [this k not-found])
   (-seq       [this]))

--- a/src/clj/clojure/lang/persistent_array_map.clj
+++ b/src/clj/clojure/lang/persistent_array_map.clj
@@ -53,9 +53,10 @@
       (arr/array-set! new-array 1 v)
       (make-array-map new-array new-size (/ new-size 2)))))
 
-(defn- array-map-lookup [arr size key]
-  (when-let [idx (index-of arr size key)]
-    (arr/array-get arr (inc idx))))
+(defn- array-map-lookup [arr size key not-found]
+  (if-let [idx (index-of arr size key)]
+    (arr/array-get arr (inc idx))
+    not-found))
 
 (defn- array-map-equals? [-seq -count other]
   (if (= -count (count other))
@@ -140,8 +141,8 @@
     (list '-dissoc ['this 'k]
           (list 'array-map-dissoc 'this '-arr '-size '-count 'k))
 
-    (list '-lookup ['this 'key]
-          (list 'array-map-lookup '-arr '-size 'key))
+    (list '-lookup ['this 'k 'not-found]
+          (list 'array-map-lookup '-arr '-size 'k 'not-found))
 
     (list '-seq ['this] '-seq)
 

--- a/src/clj/clojure/lang/persistent_map.clj
+++ b/src/clj/clojure/lang/persistent_map.clj
@@ -11,8 +11,9 @@
 (defn dissoc [m k]
   (-dissoc m k))
 
-(defn get [m k]
-  (-lookup m k))
+(defn get
+  ([m k] (-lookup m k nil))
+  ([m k not-found] (-lookup m k not-found)))
 
 (defn seq [m]
   (-seq m))

--- a/test/clj/clojure/lang/persistent_array_map_test.clj
+++ b/test/clj/clojure/lang/persistent_array_map_test.clj
@@ -136,6 +136,10 @@
     (let [m1 (array-map :k1 1)]
       (is (not (contains? m1 1)))))
 
+  (testing "returns a provided not-found value when using get"
+    (let [m1 (array-map)]
+      (is (= "not found" (get m1 :not-a-key "not found")))))
+
   )
 
 (deftest map-seq-test


### PR DESCRIPTION
My first attempt was to do the following

src/clj/clojure/lang/ipersistent_map.clj

``` clojure
(-lookup    [this k] [this k not-found])
```

src/clj/clojure/lang/persistent_array_map.clj

``` clojure
    (list '-lookup
      (list ['this 'k]
            (list 'array-map-lookup '-arr '-size 'k))
      (list ['this 'k 'not-found]
            (list 'if (list 'array-map-contains? '-arr '-size 'k)
                      (list 'array-map-lookup '-arr '-size 'k)
                      'not-found)))
```

src/clj/clojure/lang/persistent_map.clj

``` clojure
(defn get
   ([m k] (-lookup m k))
   ([m k not-found] (-lookup m k not-found)))
```

which is how clojure does it, but I kept running into

``` clojure
Unsupported binding form: (array-map-lookup -arr -size k) 
```

with the macro in src/clj/clojure/lang/persistent_array_map.clj

I abandoned that in favor of the current approach, and I think it's nicer because it keeps the `IPersistentMap` interface smaller and makes the default of get/2 explicit. Thoughts? 

I implemented this because I need to default keys in a configuration map.
