### PR TITLE
Begin to implement PersistentHashSet. Introduces IPersistentSet.

### DIFF
--- a/src/clj/clojure/lang/atom.clj
+++ b/src/clj/clojure/lang/atom.clj
@@ -6,8 +6,8 @@
             [clojure.lang.ivalidatable           :refer [IValidatable]]
             [clojure.lang.iwatchable             :refer [IWatchable]]
             [clojure.lang.comparison             :refer [=]]
+            [clojure.lang.lookup                 :refer [get]]
             [clojure.lang.persistent-array-map   :refer [array-map]]
-            [clojure.lang.persistent-map         :refer [get]]
             [clojure.lang.platform.atomic-entity :as    ent]
             [clojure.lang.platform.exceptions    :refer [new-illegal-state-error]]))
 

--- a/src/clj/clojure/lang/ilookup.clj
+++ b/src/clj/clojure/lang/ilookup.clj
@@ -2,4 +2,5 @@
   (:refer-clojure :refer [defprotocol]))
 
 (defprotocol ILookup
-  (-lookup [this k]))
+  (-includes? [this k])
+  (-lookup [this k not-found]))

--- a/src/clj/clojure/lang/ipersistent_map.clj
+++ b/src/clj/clojure/lang/ipersistent_map.clj
@@ -3,7 +3,4 @@
 
 (defprotocol IPersistentMap
   (-assoc     [this k v])
-  (-contains? [this k])
-  (-dissoc    [this k])
-  (-lookup    [this k not-found])
-  (-seq       [this]))
+  (-dissoc    [this k]))

--- a/src/clj/clojure/lang/ipersistent_set.clj
+++ b/src/clj/clojure/lang/ipersistent_set.clj
@@ -1,0 +1,9 @@
+(ns clojure.lang.ipersistent-set
+  (:refer-clojure :only [defprotocol]))
+
+(defprotocol IPersistentSet
+  (-conj [this xs])
+  (-difference [this sets])
+  (-disj [this xs])
+  (-intersection [this sets])
+  (-union [this sets]))

--- a/src/clj/clojure/lang/iseqable.clj
+++ b/src/clj/clojure/lang/iseqable.clj
@@ -1,0 +1,5 @@
+(ns clojure.lang.iseqable
+  (:refer-clojure :only [defprotocol]))
+
+(defprotocol ISeqable
+  (-seq [this]))

--- a/src/clj/clojure/lang/lookup.clj
+++ b/src/clj/clojure/lang/lookup.clj
@@ -1,0 +1,11 @@
+(ns clojure.lang.lookup
+  (:refer-clojure :only [defn])
+  (:require [clojure.lang.ilookup :refer [-includes? -lookup]]))
+
+(defn contains? [coll k]
+  (-includes? coll k))
+
+(defn get
+  ([coll k] (-lookup coll k nil))
+  ([coll k not-found] (-lookup coll k not-found)))
+

--- a/src/clj/clojure/lang/persistent_array_map.clj
+++ b/src/clj/clojure/lang/persistent_array_map.clj
@@ -3,19 +3,21 @@
   (:require [clojure.lang.comparison             :refer [= not=]]
             [clojure.lang.counted                :refer [count]]
             [clojure.lang.icounted               :refer [ICounted]]
+            [clojure.lang.ilookup                :refer [ILookup]]
             [clojure.lang.ipersistent-map        :refer [IPersistentMap]]
             [clojure.lang.iseq                   :refer [ISeq]]
+            [clojure.lang.iseqable               :refer [ISeqable]]
             [clojure.lang.hash                   :refer [hash]]
             [clojure.lang.logical                :refer [not]]
+            [clojure.lang.lookup                 :refer [contains? get]]
             [clojure.lang.map-entry              :refer [make-map-entry key val]]
-            [clojure.lang.persistent-map         :refer [get seq contains?]]
             [clojure.lang.platform.hash          :refer [platform-hash-method]]
             [clojure.lang.platform.comparison    :refer [platform-equals-method]]
             [clojure.lang.platform.enumerable    :refer [platform-enumerable-method]]
             [clojure.lang.platform.exceptions    :refer [new-argument-error]]
             [clojure.lang.platform.mutable-array :as    arr]
             [clojure.lang.platform.object        :refer [expand-methods]]
-            [clojure.lang.seq                    :refer [first next]]))
+            [clojure.lang.seq                    :refer [first next seq]]))
 
 (defn- index-of [arr size value]
   (loop [i 0]
@@ -118,6 +120,7 @@
   (list 'array-map-hash '-seq))
 
 (def platform-array-map-methods
+  ^{:private true}
   (-> {}
     (platform-hash-method 'array-map-hash-init)
     ;platform-show-method
@@ -132,19 +135,21 @@
     'ICounted
     (list '-count ['this] '-count)
 
+    'ILookup
+    (list '-lookup ['this 'k 'not-found]
+          (list 'array-map-lookup '-arr '-size 'k 'not-found))
+
+    (list '-includes? ['this 'k]
+          (list 'array-map-contains? '-arr '-size 'k))
+
     'IPersistentMap
     (list '-assoc ['this 'k 'v]
           (list 'array-map-assoc 'this '-arr '-size '-count 'k 'v))
 
-    (list '-contains? ['this 'k]
-          (list 'array-map-contains? '-arr '-size 'k))
-
     (list '-dissoc ['this 'k]
           (list 'array-map-dissoc 'this '-arr '-size '-count 'k))
 
-    (list '-lookup ['this 'k 'not-found]
-          (list 'array-map-lookup '-arr '-size 'k 'not-found))
-
+    'ISeqable
     (list '-seq ['this] '-seq)
 
     platform-array-map-methods))

--- a/src/clj/clojure/lang/persistent_hash_set.clj
+++ b/src/clj/clojure/lang/persistent_hash_set.clj
@@ -1,0 +1,120 @@
+(ns clojure.lang.persistent-hash-set
+  (:refer-clojure :only [apply assoc cons declare defmacro defn defn- deftype dissoc empty? every? first fn flatten hash-map keys let list list* loop map next reduce repeat rest take + ->])
+  (:require [clojure.lang.icounted            :refer [ICounted]]
+            [clojure.lang.ilookup             :refer [ILookup]]
+            [clojure.lang.ipersistent-set     :refer [IPersistentSet]]
+            [clojure.lang.iseqable            :refer [ISeqable]]
+            [clojure.lang.comparison          :refer [=]]
+            [clojure.lang.counted             :refer [count]]
+            [clojure.lang.hash                :refer [hash]]
+            [clojure.lang.lookup              :refer [contains?]]
+            [clojure.lang.seq                 :refer [seq]]
+            [clojure.lang.platform.comparison :refer [platform-equals-method]]
+            [clojure.lang.platform.hash       :refer [platform-hash-method]]
+            [clojure.lang.platform.object     :refer [expand-methods]]))
+
+(defn- make-pairs [xs]
+  (flatten (map #(take 2 (repeat %)) xs)))
+
+(defn- sets-reduce [accumulator-fn -hash-map sets]
+  (loop [remaining-sets sets
+         new-hash-map   -hash-map]
+    (if (empty? remaining-sets)
+      new-hash-map
+      (recur (rest remaining-sets)
+             (accumulator-fn new-hash-map (seq (first remaining-sets)))))))
+
+(defn- hash-set-difference [-hash-map sets]
+  (sets-reduce #(apply dissoc (cons %1 %2)) -hash-map sets))
+
+(defn- hash-set-union [-hash-map sets]
+  (sets-reduce #(apply assoc (cons %1 (make-pairs %2))) -hash-map sets))
+
+(defn- hash-set-intersection [test-items sets]
+  (reduce
+    (fn [acc x]
+      (if (every? #(contains? % x) sets)
+          (assoc acc x x)
+          acc))
+    (hash-map) test-items))
+
+(defn- hash-set-hash [items-seq]
+  (reduce #(+ %1 (hash %2)) 0 items-seq))
+
+(defn- hash-set-equals? [-hash-map other-set]
+  (let [ks (keys -hash-map)]
+    (if (= (clojure.core/count ks) (count other-set))
+        (every? #(contains? other-set %) ks)
+        false)))
+
+(defmacro hash-set-hash-init
+  {:private true}
+  [this]
+  (list 'hash-set-hash (list 'seq this)))
+
+(defmacro hash-set-equals?-init
+  {:private true}
+  [this other-set]
+  (list 'hash-set-equals? '-hash-map other-set))
+
+(declare make-hash-set)
+
+(def platform-hash-set-methods
+  ^{:private true}
+  (-> {}
+    (platform-hash-method 'hash-set-hash-init)
+    (platform-equals-method 'hash-set-equals?-init)
+    expand-methods))
+
+(defmacro defpersistenthashset [type]
+  (list*
+    'deftype type ['-hash-map]
+
+    'ICounted
+    (list '-count ['this]
+      (list 'clojure.core/count (list 'keys '-hash-map)))
+
+    'ILookup
+    (list '-lookup ['this 'x 'default]
+      (list 'clojure.core/get '-hash-map 'x 'default))
+
+    (list '-includes? ['this 'x]
+      (list 'clojure.core/contains? '-hash-map 'x))
+
+    'IPersistentSet
+    (list '-conj ['this 'xs]
+      (list 'let ['new-hash-map (list 'apply 'assoc '-hash-map (list 'make-pairs 'xs))]
+        (list 'make-hash-set 'new-hash-map)))
+
+    (list '-difference ['this 'sets]
+      (list 'let ['new-hash-map (list 'hash-set-difference '-hash-map 'sets)]
+        (list 'make-hash-set 'new-hash-map)))
+
+    (list '-disj ['this 'xs]
+      (list 'let ['new-hash-map (list 'apply 'dissoc '-hash-map 'xs)]
+        (list 'make-hash-set 'new-hash-map)))
+
+    (list '-intersection ['this 'sets]
+      (list 'let ['new-hash-map (list 'hash-set-intersection (list 'keys '-hash-map) 'sets)]
+        (list 'make-hash-set 'new-hash-map)))
+
+    (list '-union ['this 'sets]
+      (list 'let ['new-hash-map (list 'hash-set-union '-hash-map 'sets)]
+        (list 'make-hash-set 'new-hash-map)))
+
+    'ISeqable
+    (list '-seq ['this]
+      (list 'clojure.core/seq (list 'keys '-hash-map)))
+
+    platform-hash-set-methods))
+
+(defpersistenthashset PersistentHashSet)
+
+(defn- make-hash-set [-hash-map]
+  (PersistentHashSet. -hash-map))
+
+(defn hash-set
+  ([] (make-hash-set (hash-map)))
+  ([& xs]
+    (let [pairs (make-pairs xs)]
+      (make-hash-set (apply hash-map pairs)))))

--- a/src/clj/clojure/lang/persistent_map.clj
+++ b/src/clj/clojure/lang/persistent_map.clj
@@ -1,19 +1,9 @@
 (ns clojure.lang.persistent-map
   (:refer-clojure :only [defn])
-  (:require [clojure.lang.ipersistent-map :refer [-assoc -dissoc -lookup -seq -contains?]]))
+  (:require [clojure.lang.ipersistent-map :refer [-assoc -dissoc]]))
 
 (defn assoc [m k v]
   (-assoc m k v))
 
-(defn contains? [m k]
-  (-contains? m k))
-
 (defn dissoc [m k]
   (-dissoc m k))
-
-(defn get
-  ([m k] (-lookup m k nil))
-  ([m k not-found] (-lookup m k not-found)))
-
-(defn seq [m]
-  (-seq m))

--- a/src/clj/clojure/lang/persistent_set.clj
+++ b/src/clj/clojure/lang/persistent_set.clj
@@ -1,0 +1,40 @@
+(ns clojure.lang.persistent-set
+  (:refer-clojure :only [and cons defn every? let not <= >=])
+  (:require [clojure.lang.ipersistent-set     :refer [-conj -difference -disj -intersection -union]]
+            [clojure.lang.counted             :refer [count]]
+            [clojure.lang.lookup              :refer [contains?]]
+            [clojure.lang.persistent-hash-set :refer [hash-set]]
+            [clojure.lang.seq                 :refer [seq]]))
+
+(defn conj
+  ([this x] (-conj this [x]))
+  ([this x & xs] (-conj this (cons x xs))))
+
+(defn difference
+  ([this] this)
+  ([this s] (-difference this [s]))
+  ([this s & sets] (-difference this (cons s sets))))
+
+(defn disj
+  ([this] this)
+  ([this x] (-disj this [x]))
+  ([this x & xs] (-disj this (cons x xs))))
+
+(defn intersection
+  ([this s] (-intersection this [s]))
+  ([this s1 s2] (-intersection this [s1 s2]))
+  ([this s1 s2 & sets] (-intersection this (cons s1 (cons s2 sets)))))
+
+(defn subset? [s1 s2]
+  (and (<= (count s1) (count s2))
+       (every? #(contains? s2 %) (seq s1))))
+
+(defn superset? [s1 s2]
+  (and (>= (count s1) (count s2))
+       (every? #(contains? s1 %) (seq s2))))
+
+(defn union
+  ([] (hash-set))
+  ([this] this)
+  ([this s] (-union this [s]))
+  ([this s & sets] (-union this (cons s sets))))

--- a/src/clj/clojure/lang/seq.clj
+++ b/src/clj/clojure/lang/seq.clj
@@ -1,9 +1,13 @@
 (ns clojure.lang.seq
   (:refer-clojure :only [defn])
-  (:require [clojure.lang.iseq :refer [-first -next]]))
+  (:require [clojure.lang.iseq     :refer [-first -next]]
+            [clojure.lang.iseqable :refer [-seq]]))
 
 (defn first [s]
   (-first s))
 
 (defn next [s]
   (-next s))
+
+(defn seq [i]
+  (-seq i))

--- a/src/jvm/clojure/lang/platform/enumerable.clj
+++ b/src/jvm/clojure/lang/platform/enumerable.clj
@@ -18,8 +18,6 @@
   (remove [this]
     (throw (UnsupportedOperationException. "What're you gonna do?"))))
 
-(def seq-iterator-type SeqIterator)
-
 (defn new-seq-iterator [-seq-atom]
   (SeqIterator. -seq-atom))
 
@@ -31,5 +29,5 @@
                  (list 'iterator ['this]
                        (list 'clojure.lang.platform.enumerable/new-seq-iterator
                              (list 'clojure.core/atom
-                                   (list 'clojure.lang.persistent-map/seq 'this))))
+                                   (list 'clojure.lang.seq/seq 'this))))
                  old))))

--- a/test/clj/clojure/lang/persistent_array_map_test.clj
+++ b/test/clj/clojure/lang/persistent_array_map_test.clj
@@ -6,12 +6,13 @@
             [clojure.lang.hash                 :refer [hash]]
             [clojure.lang.ihash                :refer [IHash]]
             [clojure.lang.logical              :refer [not]]
+            [clojure.lang.lookup               :refer [contains? get]]
             [clojure.lang.map-entry            :refer [key val]]
-            [clojure.lang.persistent-map       :refer [assoc dissoc get seq contains?]]
+            [clojure.lang.persistent-map       :refer [assoc dissoc]]
             [clojure.lang.persistent-array-map :refer :all]
             [clojure.lang.platform.object      :refer [identical?]]
             [clojure.lang.platform.exceptions  :refer [argument-error]]
-            [clojure.lang.seq                  :refer [first next]]))
+            [clojure.lang.seq                  :refer [first next seq]]))
 
 (defmacro argument-error-is-thrown? [msg & body]
   (list 'is (list* 'thrown-with-msg? argument-error msg body)))

--- a/test/clj/clojure/lang/persistent_hash_set_test.clj
+++ b/test/clj/clojure/lang/persistent_hash_set_test.clj
@@ -1,0 +1,188 @@
+(ns clojure.lang.persistent-hash-set-test
+  (:refer-clojure :only [deftype first let next nil? sort])
+  (:require [clojure.test                     :refer :all]
+            [clojure.lang.ihash               :refer [IHash]]
+            [clojure.lang.comparison          :refer [=]]
+            [clojure.lang.counted             :refer [count]]
+            [clojure.lang.hash                :refer [hash]]
+            [clojure.lang.logical             :refer [not]]
+            [clojure.lang.lookup              :refer [contains? get]]
+            [clojure.lang.persistent-set      :refer [conj difference disj intersection subset? superset? union]]
+            [clojure.lang.persistent-hash-set :refer :all]
+            [clojure.lang.seq                 :refer [seq]]))
+
+(deftest persistent-hash-set-test
+  (testing "an empty hash set does not contains? an item"
+    (let [s1 (hash-set)]
+      (is (not (contains? s1 :anything)))))
+
+  (testing "a hash set contains? an item"
+    (let [s1 (hash-set "item")]
+      (is (contains? s1 "item"))))
+
+  (testing "count set entries"
+    (is (= 0 (count (hash-set))))
+    (is (= 1 (count (hash-set :one))))
+    (is (= 2 (count (hash-set :one :two)))))
+
+  (testing "get returns the element if it is a member of the set and nil otherwise"
+    (let [s1 (hash-set 1)]
+      (is (= 1 (get s1 1)))
+      (is (nil? (get s1 2)))))
+
+  (testing "get returns a default value if not part of the set"
+    (let [s1 (hash-set 1)]
+      (is (= 1 (get s1 1 :default)))
+      (is (= :default (get s1 2 :default)))))
+
+  (testing "conj an item to a hash set"
+    (let [s1 (hash-set)
+          s2 (conj s1 "item")]
+      (is (contains? s2 "item"))))
+
+  (testing "conj many items to a hash set"
+    (let [s1 (hash-set)
+          s2 (conj s1 1 2 3)]
+      (is (contains? s2 1))
+      (is (contains? s2 2))
+      (is (contains? s2 3))))
+
+  (testing "disj from an empty set is identity"
+    (let [s1 (hash-set)]
+      (is (= s1 (disj s1)))))
+
+  (testing "disj an entry from a set"
+    (let [s1 (hash-set 1)]
+      (is (= (hash-set) (disj s1 1)))))
+
+  (testing "disj multiple entries from a set"
+    (let [s1 (hash-set 1 2 3 4 5)
+          s2 (hash-set 2 4)]
+      (is (= s2 (disj s1 1 3 5)))))
+
+  (testing "difference of a single set is identity"
+    (let [s1 (hash-set 1 2 3)]
+      (is (= s1 (difference s1)))))
+
+  (testing "difference of two sets"
+    (let [s1 (hash-set 1 2)
+          s2 (hash-set 2 3)
+          s3 (hash-set 1)]
+      (is (= s3 (difference s1 s2)))))
+
+  (testing "difference of many sets"
+    (let [s1 (hash-set 1 2 3 4)
+          s2 (hash-set 1)
+          s3 (hash-set 4 5)
+          s4 (hash-set 2 3)]
+      (is (= s4 (difference s1 s2 s3)))))
+
+  (testing "intersection of two sets"
+    (let [s1 (hash-set 1 2 3 5)
+          s2 (hash-set 1 3 4)]
+      (is (= (hash-set 1 3) (intersection s1 s2)))))
+
+  (testing "intersection of many sets"
+    (let [s1 (hash-set 1 2 3 5)
+          s2 (hash-set 1 3 5 6)
+          s3 (hash-set 3 4 5 6)]
+      (is (= (hash-set 3 5) (intersection s1 s2 s3)))))
+
+  (testing "union without args returns a new set"
+    (is (= (hash-set) (union))))
+
+  (testing "union with a single set is identity"
+    (let [s1 (hash-set 1 2 3)]
+      (is (= s1 (union s1)))))
+
+  (testing "union of two sets"
+    (let [s1 (hash-set 1 2)
+          s2 (hash-set 2 3)
+          s3 (hash-set 1 2 3)]
+      (is (= s3 (union s1 s2)))))
+
+  (testing "union of many sets"
+    (let [s1 (hash-set 1 2)
+          s2 (hash-set :foo :bar)
+          s3 (hash-set "baz" 3.14 1)
+          s4 (hash-set 1 2 :foo :bar "baz" 3.14)]
+      (is (= s4 (union s1 s2 s3)))))
+
+  (testing "a set is a subset? of an equivalent set"
+    (is (subset? (hash-set) (hash-set)))
+    (is (subset? (hash-set :item) (hash-set :item))))
+
+  (testing "a set is not a subset? of another"
+    (let [s1 (hash-set 1 2 3)
+          s2 (hash-set 2)]
+      (is (not (subset? s1 s2)))))
+
+  (testing "a set is a subset? of another"
+    (let [s1 (hash-set 2)
+          s2 (hash-set 1 2 3)]
+      (is (subset? s1 s2))))
+
+  (testing "a set is a superset? of an equivalent set"
+    (is (superset? (hash-set) (hash-set)))
+    (is (superset? (hash-set :item) (hash-set :item))))
+
+  (testing "a set is not a superset? of another"
+    (let [s1 (hash-set 2)
+          s2 (hash-set 1 2 3)]
+      (is (not (superset? s1 s2)))))
+
+  (testing "a set is a subset? of another"
+    (let [s1 (hash-set 1 2 32)
+          s2 (hash-set 2)]
+      (is (superset? s1 s2))))
+
+  )
+
+(deftype Thing [t]
+  IHash
+  (-hash [this] t))
+
+(deftest persistent-hash-set-hash-test
+  (testing "the hash of an empty set is zero"
+    (let [s1 (hash-set)]
+      (is (= 0 (hash s1)))))
+
+  (testing "calculates the sum of all of it's elements hash codes"
+    (let [thing1 (Thing. 42)
+          thing2 (Thing. 24)
+          thing3 (Thing. 1337)
+          s1 (hash-set thing1 thing2 thing3)]
+      (is (= 1403 (hash s1)))))
+
+  (testing "hash of two identical sets will be the same"
+    (let [s1 (hash-set 1 2 3)
+          s2 (hash-set 1 2 3)]
+      (is (= (hash s1) (hash s2)))))
+  )
+
+(deftest persistent-hash-set-equality-test
+  (testing "two sets are equal"
+    (is (= (hash-set) (hash-set)))
+    (is (= (hash-set 1 2) (hash-set 1 2))))
+
+  (testing "a superset is not equal to its subset"
+    (is (not (= (hash-set 1 2) (hash-set 1))))
+    (is (not (= (hash-set 1)   (hash-set 1 2)))))
+
+  )
+
+(deftest persistent-hash-set-seq-test
+  (testing "seq returns nil when the set is empty"
+    (is (nil? (seq (hash-set)))))
+
+  (testing "first gives a set element"
+    (let [s1 (hash-set 1)]
+      (is (= 1 (first (seq s1))))))
+
+  (testing "next returns nil when there is only one entry"
+    (is (nil? (next (seq (hash-set 1))))))
+
+  (testing "next returns the next sequence"
+    (is (= 2 (first (next (seq (hash-set 1 2)))))))
+
+  )

--- a/test/jvm/clojure/lang/platform/persistent_array_map_test.clj
+++ b/test/jvm/clojure/lang/platform/persistent_array_map_test.clj
@@ -4,9 +4,8 @@
             [clojure.lang.comparison           :refer [=]]
             [clojure.lang.hash                 :refer [hash]]
             [clojure.lang.logical              :refer [not]]
-            [clojure.lang.persistent-map       :refer [seq]]
             [clojure.lang.persistent-array-map :refer [array-map]]
-            [clojure.lang.seq                  :refer [first next]])
+            [clojure.lang.seq                  :refer [first next seq]])
   (:import [java.util NoSuchElementException]))
 
 (deftest platform-equals-test


### PR DESCRIPTION
The functions `project`, `rename-keys`, `rename`, `index`, `map-invert`, & `join` all deal with meta or deal with sets of maps, and are not yet in the set namespace. I plan on doing them next, however I did a few refactors and didn't want to drift from master.
