### PR TITLE
Write left and right red-node assoc rebalance tests. Fixes add-left bug.

### DIFF
--- a/src/clj/clojure/lang/persistent_sorted_map.clj
+++ b/src/clj/clojure/lang/persistent_sorted_map.clj
@@ -65,9 +65,9 @@
   (-add-right [this node]
     (-balance-right node this))
   (-remove-left [this node]
-    (balance-left-del -map-entry nil node nil))
+    (balance-left-del -map-entry node nil))
   (-remove-right [this node]
-    (balance-right-del -map-entry nil nil node))
+    (balance-right-del -map-entry nil node))
   (-balance-left [this node]
     (make-black-node (-entry node) this (-right node)))
   (-balance-right [this node]
@@ -91,9 +91,9 @@
   (-add-right [this node]
     (-balance-right node this))
   (-remove-left [this node]
-    (balance-left-del -map-entry nil node nil))
+    (balance-left-del -map-entry node nil))
   (-remove-right [this node]
-    (balance-right-del -map-entry nil nil node))
+    (balance-right-del -map-entry nil node))
   (-balance-left [this node]
     (make-black-node (-entry node) this (-right node)))
   (-balance-right [this node]
@@ -117,9 +117,9 @@
   (-add-right [this node]
     (-balance-right node this))
   (-remove-left [this node]
-    (balance-left-del -map-entry nil node nil))
+    (balance-left-del -map-entry node -right-node))
   (-remove-right [this node]
-    (balance-right-del -map-entry nil nil node))
+    (balance-right-del -map-entry -left-node node))
   (-balance-left [this node]
     (make-black-node (-entry node) this (-right node)))
   (-balance-right [this node]
@@ -143,9 +143,9 @@
   (-add-right [this node]
     (-balance-right node this))
   (-remove-left [this node]
-    (balance-left-del -map-entry nil node nil))
+    (balance-left-del -map-entry node -right-node))
   (-remove-right [this node]
-    (balance-right-del -map-entry nil nil node))
+    (balance-right-del -map-entry -left-node node))
   (-balance-left [this node]
     (make-black-node (-entry node) this (-right node)))
   (-balance-right [this node]
@@ -219,22 +219,22 @@
   (-left [this] -left-node)
   (-right [this] -right-node)
   (-add-left [this node]
-    (make-red-node -map-entry node nil))
+    (make-red-node -map-entry node -right-node))
   (-add-right [this node]
-    (make-red-node -map-entry nil node))
+    (make-red-node -map-entry -left-node node))
   (-remove-left [this node]
-    (make-red-node -map-entry node nil))
+    (make-red-node -map-entry node -right-node))
   (-remove-right [this node]
-    (make-red-node -map-entry nil node))
+    (make-red-node -map-entry -left-node node))
   (-balance-left [this node]
     (cond
       (red-node? -left-node)
         (let [blackened-node (make-black-node (-entry node) -right-node (-right node))]
           (make-red-node -map-entry (-blacken -left-node) blackened-node))
       (red-node? -right-node)
-        (let [blackened (make-black-node -map-entry -left-node (-right -left-node))
+        (let [blackened (make-black-node -map-entry -left-node (-left -right-node))
               blackened-right (make-black-node (-entry node) (-right -right-node) (-right node))]
-          (make-red-node -map-entry blackened blackened-right))
+          (make-red-node (-entry -right-node) -map-entry blackened blackened-right))
       :else
         (make-black-node (-entry node) this (-right node))))
   (-balance-right [this node]
@@ -264,22 +264,22 @@
   (-left [this] -left-node)
   (-right [this] -right-node)
   (-add-left [this node]
-    (make-red-node -map-entry node nil))
+    (make-red-node -map-entry node -right-node))
   (-add-right [this node]
-    (make-red-node -map-entry nil node))
+    (make-red-node -map-entry -left-node node))
   (-remove-left [this node]
-    (make-red-node -map-entry node nil))
+    (make-red-node -map-entry node -right-node))
   (-remove-right [this node]
-    (make-red-node -map-entry nil node))
+    (make-red-node -map-entry -left-node node))
   (-balance-left [this node]
     (cond
       (red-node? -left-node)
         (let [blackened-node (make-black-node (-entry node) -right-node (-right node))]
           (make-red-node -map-entry (-blacken -left-node) blackened-node))
       (red-node? -right-node)
-        (let [blackened (make-black-node -map-entry -left-node (-right -left-node))
+        (let [blackened (make-black-node -map-entry -left-node (-left -right-node))
               blackened-right (make-black-node (-entry node) (-right -right-node) (-right node))]
-          (make-red-node -map-entry blackened blackened-right))
+          (make-red-node (-entry -right-node) blackened blackened-right))
       :else
         (make-black-node (-entry node) this (-right node))))
   (-balance-right [this node]

--- a/test/clj/clojure/lang/persistent_sorted_map_test.clj
+++ b/test/clj/clojure/lang/persistent_sorted_map_test.clj
@@ -2,14 +2,41 @@
   (:refer-clojure :only [let nil? >])
   (:require [clojure.test                       :refer :all]
             [clojure.lang.counted               :refer [count]]
+            [clojure.lang.lookup                :refer [contains? get]]
             [clojure.lang.map-entry             :refer [key val]]
             [clojure.lang.operators             :refer [=]]
+            [clojure.lang.persistent-map        :refer [assoc]]
             [clojure.lang.persistent-map-test   :refer [map-test]]
             [clojure.lang.persistent-sorted-map :refer :all]
             [clojure.lang.seq                   :refer [seq first next]]))
 
 (deftest sorted-map-test
   (map-test "PersistentSortedMap" sorted-map))
+
+(deftest sorted-map-rebalance-test
+  (testing "assoc to an existing key"
+    (let [m1 (sorted-map :k1 :v1)
+          m2 (assoc m1 :k1 :v2)]
+      (is (= 1 (count m1)))
+      (is (= 1 (count m2)))
+      (is (= :v1 (get m1 :k1)))
+      (is (= :v2 (get m2 :k1)))))
+
+  (testing "rebalances a red branch left"
+    (let [m1 (sorted-map 1 :v2 3 :v3 2 :v1)]
+      (is (= 3 (count m1)))
+      (is (contains? m1 1))
+      (is (contains? m1 2))
+      (is (contains? m1 3))))
+
+  (testing "rebalances a red branch right"
+    (let [m1 (sorted-map-by > 1 :v1 3 :v3 2 :v2)]
+      (is (= 3 (count m1)))
+      (is (contains? m1 1))
+      (is (contains? m1 2))
+      (is (contains? m1 3))))
+
+  )
 
 (deftest sorted-map-seq-test
   (testing "seq return nil when the map is empty"

--- a/test/jvm/clojure/lang/platform/persistent_sorted_map_test.clj
+++ b/test/jvm/clojure/lang/platform/persistent_sorted_map_test.clj
@@ -4,5 +4,5 @@
             [clojure.lang.platform.persistent-map-test :refer [platform-map-test]]
             [clojure.lang.persistent-sorted-map        :refer [sorted-map]]))
 
-;(deftest sorted-map-platform-test
-;  (platform-map-test sorted-map))
+(deftest sorted-map-platform-test
+  (platform-map-test sorted-map))


### PR DESCRIPTION
Adds two rebalancing cases, one of which caught a bug. Up next are dissoc rebalance cases, followed by generative tests.
