### PR TITLE
Add unsigned bit shift right

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]]
 
   :source-paths ["src/clj" "src/jvm"]
   :java-source-paths ["src/jvm" "test/jvm"]

--- a/src/clj/clojure/lang/persistent_hash_map.clj
+++ b/src/clj/clojure/lang/persistent_hash_map.clj
@@ -6,11 +6,11 @@
             [clojure.lang.map-entry              :refer [new-map-entry]]
             [clojure.lang.platform.exceptions    :refer [new-argument-error]]
             [clojure.lang.platform.hash-map      :refer [->bitnum empty-object
-                                                         bit-and bit-or bit-xor bit-shift-left
+                                                         bit-and bit-or bit-xor bit-shift-left unsigned-bit-shift-right
                                                          + inc * - dec]]
             [clojure.lang.protocols              :refer [IAssociative ICounted ILookup
                                                          IMeta IPersistentMap ISeqable ISeq]]
-            [clojure.next                        :refer :all :exclude [and bit-and bit-or bit-xor bit-shift-left
+            [clojure.next                        :refer :all :exclude [and bit-and bit-or bit-xor bit-shift-left unsigned-bit-shift-right
                                                                        + inc * - dec]]))
 
 (def ^:private NEG-ONE    (->bitnum -1))
@@ -58,7 +58,7 @@
 
 (defn- mask [hash shift]
   (bit-and
-    (bit-unsigned-shift-right hash shift)
+    (unsigned-bit-shift-right hash shift)
     BITMASK))
 
 (defn- bit-pos [hash shift]
@@ -304,7 +304,7 @@
               (aset nodes jdx jdx-node)
               (loop [i ZERO j ZERO]
                 (when (< i THIRTY-TWO)
-                  (if (not= (bit-and (bit-unsigned-shift-right bitmap i) ONE) ZERO)
+                  (if (not= (bit-and (unsigned-bit-shift-right bitmap i) ONE) ZERO)
                     (do
                       (if (nil? (aget arr j))
                         (aset nodes i (aget arr (inc j)))
@@ -364,7 +364,7 @@
                     jdx-node (node-assoc-ref EMPTY-BitmapIndexedNode edit (+ FIVE shift) hash key val added-leaf)]
                 (loop [i ZERO j ZERO]
                   (when (< i THIRTY-TWO)
-                    (if (not= (bit-and (bit-unsigned-shift-right i) ONE) ZERO)
+                    (if (not= (bit-and (unsigned-bit-shift-right bitmap i) ONE) ZERO)
                       (do
                         (if (nil? (aget arr j))
                           (aset nodes i (aget (inc j)))

--- a/src/clj/clojure/lang/persistent_vector.clj
+++ b/src/clj/clojure/lang/persistent_vector.clj
@@ -1,9 +1,9 @@
 (ns clojure.lang.persistent-vector
-  (:refer-clojure :only [cond declare defn- defn defprotocol deftype dec inc integer? let loop when < > >= ->])
-  (:require [clojure.next                     :refer :all :exclude [dec inc]]
+  (:refer-clojure :only [cond declare defn- defn defprotocol deftype integer? let loop when < > >= ->])
+  (:require [clojure.next                     :refer :all :exclude [bit-shift-left unsigned-bit-shift-right]]
             [clojure.lang.platform.exceptions :refer [new-argument-error new-out-of-bounds-exception]]
             [clojure.lang.numbers             :refer [->int]]
-            [clojure.lang.platform.hash-map   :refer [->bitnum]]
+            [clojure.lang.platform.hash-map   :refer [->bitnum bit-shift-left unsigned-bit-shift-right]]
             [clojure.lang.protocols           :refer [-as-transient -assoc-n -conj! -persistent
                                                       IAssociative ICounted IEditableCollection IMeta IPersistentVector
                                                       ISeq ISeqable ITransientCollection IIndexed]]))
@@ -54,7 +54,7 @@
   (if (< length 32)
     0
     (-> (->bitnum (dec length))
-        (bit-unsigned-shift-right (->bitnum 5))
+        (unsigned-bit-shift-right (->bitnum 5))
         (bit-shift-left (->bitnum 5)))))
 
 (defn- new-path [edit level node]
@@ -65,7 +65,7 @@
       new-node)))
 
 (defn- push-tail [level parent-node tail-node length root]
-  (let [subidx (bit-and (->int (bit-unsigned-shift-right (->bitnum (dec length)) (->bitnum level))) (->bitnum 0x01f))
+  (let [subidx (bit-and (->int (unsigned-bit-shift-right (->bitnum (dec length)) (->bitnum level))) (->bitnum 0x01f))
         new-node (make-node (get-edit parent-node) (aclone (get-array parent-node)))]
     (if (= level 5)
       (aset (get-array new-node) subidx tail-node)
@@ -88,7 +88,7 @@
       (let [tail-node (make-node (get-edit -root) -tail)
             new-tail (make-array 32)]
         (aset new-tail 0 x)
-        (if (> (bit-unsigned-shift-right (->bitnum -length) (->bitnum 5)) (bit-shift-left (->bitnum 1) (->bitnum -shift)))
+        (if (> (unsigned-bit-shift-right (->bitnum -length) (->bitnum 5)) (bit-shift-left (->bitnum 1) (->bitnum -shift)))
           (let [new-root (make-node (get-edit -root))]
             (aset (get-array new-root) 0 -root)
             (aset (get-array new-root) 1 (new-path (get-edit -root) -shift tail-node))
@@ -122,7 +122,7 @@
       (do
         (aset (get-array new-node) (bit-and (->bitnum n) (->bitnum 0x01f)) x)
         new-node)
-      (let [subidx (bit-and (bit-unsigned-shift-right (->bitnum n) (->bitnum level)) (->bitnum 0x01f))]
+      (let [subidx (bit-and (unsigned-bit-shift-right (->bitnum n) (->bitnum level)) (->bitnum 0x01f))]
         (aset (get-array new-node) subidx (do-assoc (- level 5) (aget (get-array node) subidx) n x))
         new-node))))
 
@@ -138,7 +138,7 @@
       (let [tail-node (make-node (get-edit -root) -tail)
             new-arr (make-array 1)]
         (aset new-arr 0 x)
-        (if (> (bit-unsigned-shift-right (->bitnum -length) (->bitnum 5)) (bit-shift-left (->bitnum 1) (->bitnum -shift)))
+        (if (> (unsigned-bit-shift-right (->bitnum -length) (->bitnum 5)) (bit-shift-left (->bitnum 1) (->bitnum -shift)))
           (let [new-root (make-node (get-edit -root))]
             (aset (get-array new-root) 0 -root)
             (aset (get-array new-root) 1 (new-path (get-edit -root) -shift tail-node))

--- a/src/clj/clojure/next.clj
+++ b/src/clj/clojure/next.clj
@@ -17,8 +17,8 @@
 (defn type [x]
   (platform-object/type x))
 
-(require ['clojure.lang.numbers :refer ['-bit-unsigned-shift-right
-                                        '-bit-count
+(require ['clojure.lang.numbers :refer ['-bit-count
+                                        'bunsigned-shift-right
                                         'bshift-left
                                         'band
                                         'bor
@@ -102,8 +102,8 @@
   [& args]
   (not (apply == args)))
 
-(defn bit-unsigned-shift-right [n shift]
-  (-bit-unsigned-shift-right n shift))
+(defn unsigned-bit-shift-right [n shift]
+  (bunsigned-shift-right n shift))
 
 (defn bit-shift-left [n shift]
   (bshift-left n shift))

--- a/src/jvm/clojure/lang/numbers.clj
+++ b/src/jvm/clojure/lang/numbers.clj
@@ -29,6 +29,9 @@
 (defmacro bshift-left [x y]
   `(. BitOps (numberBitShiftLeft ~x ~y)))
 
+(defmacro bunsigned-shift-right [x y]
+  `(. BitOps (numberUnsignedBitShiftRight ~x ~y)))
+
 (defmacro add [x y]
   `(. Addition (numberAdd ~x ~y)))
 
@@ -222,7 +225,6 @@
 
 (defprotocol Ops
   (ops-bit-count                [ops i])
-  (ops-bit-unsigned-shift-right [ops x y])
   (ops-equals                   [ops x y])
   (ops-zero?                    [ops x]))
 
@@ -242,13 +244,11 @@
 (deftype IntegerOps []
   Ops
   (ops-bit-count                 [_ i]   (Integer/bitCount i))
-  (ops-bit-unsigned-shift-right  [_ x y] (NumberOps/intBitUnsignedShiftRight (->int x) (->int y)))
   (ops-equals                    [_ x y] (-equals ->int x y)))
 
 (deftype LongOps []
   Ops
   (ops-equals                    [_ x y] (-equals ->long x y))
-  (ops-bit-unsigned-shift-right  [_ x y] (NumberOps/longBitUnsignedShiftRight (->long x) (->long y)))
   )
 
 (deftype FloatOps []
@@ -463,14 +463,13 @@
 (defmethod no-overflow-ops [BigDecimal BigDecimal]    [ops1 ops2] BIGDECIMAL-OPS)
 
 (defprotocol BitOperations
-  (-bit-count                [this])
-  (-bit-unsigned-shift-right [this shift]))
+  (-bit-count                [this]))
 
 (defn- long-hash-code [lpart]
   (unsafe-cast-int
     (bxor
       lpart
-      (-bit-unsigned-shift-right lpart 32))))
+      (bunsigned-shift-right lpart 32))))
 
 (extend-protocol IHash
   Byte
@@ -522,10 +521,6 @@
   BitOperations
   (-bit-count [i]
     (ops-bit-count (make-ops i) i))
-
-  (-bit-unsigned-shift-right [this shift]
-    (-> (no-overflow-ops (type this) (type shift))
-      (ops-bit-unsigned-shift-right this shift)))
 
   NumberCoercions
   (->long   [this] (.longValue this))

--- a/src/jvm/clojure/lang/platform/hash_map.clj
+++ b/src/jvm/clojure/lang/platform/hash_map.clj
@@ -14,6 +14,9 @@
 
 (def integer-one (int 1))
 
+(defmacro unsigned-bit-shift-right [x y]
+  `(. BitOps (integerPreserveUnsignedBitShiftRight ~x ~y)))
+
 (defmacro bit-and [x y]
   `(. BitOps (integerPreserveBitAnd ~x ~y)))
 

--- a/src/jvm/clojure/lang/platform/numbers/BitOps.java
+++ b/src/jvm/clojure/lang/platform/numbers/BitOps.java
@@ -42,5 +42,15 @@ public final class BitOps {
     return x << y;
   }
 
+  public static long numberUnsignedBitShiftRight(Object x, Object y) {
+    long lx = Coercion.toBitOperand(x);
+    long ly = Coercion.toBitOperand(y);
+    return lx >>> ly;
+  }
+
+  public static int integerPreserveUnsignedBitShiftRight(int x, int y) {
+    return x >>> y;
+  }
+
 }
 

--- a/test/clj/clojure/lang/operators_test.clj
+++ b/test/clj/clojure/lang/operators_test.clj
@@ -102,6 +102,21 @@
 
   )
 
+(deftest bit-unsigned-shift-right-test
+  (testing "returns for a numbers and a shift"
+    (is (= 1 (unsigned-bit-shift-right 3 1))))
+
+ (testing "raises an error with big numbers and decimals"
+    (argument-error-thrown? (unsigned-bit-shift-right (bigint 1) 1))
+    (argument-error-thrown? (unsigned-bit-shift-right (double 0.1) 1))
+    (argument-error-thrown? (unsigned-bit-shift-right (float 0.1) 1))
+    (argument-error-thrown? (unsigned-bit-shift-right (bigdec 0.1) 1)))
+
+  (testing "raises an error without a number type"
+    (argument-error-thrown? (unsigned-bit-shift-right "foo" 1)))
+
+  )
+
 (deftest bit-and-test
   (testing "returns for two arguments"
     (is (= 1 (bit-and 1 1))))
@@ -157,7 +172,7 @@
   )
 
 (deftest bit-shift-left-test
-  (testing "returns for two arguemnts"
+  (testing "returns for a numbers and a shift"
     (is (= 2 (bit-shift-left 1 1))))
 
  (testing "raises an error with big numbers and decimals"

--- a/test/jvm/clojure/lang/numbers_test.clj
+++ b/test/jvm/clojure/lang/numbers_test.clj
@@ -228,6 +228,17 @@
            #(bshift-left %1 %2)
            16 2 3))
 
+(deftest bit-unsigned-shift-right-test
+  (testing "works with a 0 in the signed position"
+    (op-test {Long [[byte short int long] [byte short int long]]}
+             #(bunsigned-shift-right %1 %2)
+             2 5 1))
+
+  (testing "works with a 1 in the signed position"
+    (op-test {Long [[byte short int long] [byte short int long]]}
+             #(bunsigned-shift-right %1 %2)
+             9223372036854775805 -5 1)))
+
 (deftest integer-addition-test
   (op-test {Long [[int long] [number int long]]
             clojure.lang.BigInt [[bigint biginteger] [number int long bigint biginteger]]}


### PR DESCRIPTION
  Bump to clojure 1.6.0 since unsigned-bit-shift-right was added in
  1.6.0
