### PR TITLE
RFC: Abstract test definitions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,6 @@
 
   :source-paths ["src/clj" "src/jvm"]
   :java-source-paths ["src/jvm" "test/jvm"]
-  :test-paths   ["test/clj" "test/jvm"]
+  :test-paths   ["test/clj" "test/jvm" "test/defs" "test/gold_standard"]
 
   )

--- a/test/clj/clojure/lang/agent_test.clj
+++ b/test/clj/clojure/lang/agent_test.clj
@@ -1,6 +1,7 @@
 (ns clojure.lang.agent-test
   (:refer-clojure :only [class defmacro false? fn let list list* nil? true? while])
-  (:require [clojure.test                     :refer :all]
+  (:require [clojure.lang.agent-test-def      :refer [gen-agent-test]]
+            [clojure.test                     :refer :all]
             [clojure.next                     :refer :all]
             [clojure.lang.thread              :refer [sleep]]
             [clojure.lang.platform.exceptions :refer [argument-error new-runtime-exception runtime-exception]]))
@@ -8,104 +9,5 @@
 (defmacro runtime-exception-is-thrown? [msg & body]
   (list 'is (list* 'thrown-with-msg? runtime-exception msg body)))
 
-(deftest agent-test
-  (testing "creates an agent which can be deferenced"
-    (let [agt (agent "agt")]
-      (is (= "agt" (deref agt)))))
+(gen-agent-test)
 
-  (testing "send-via the solo-executor"
-    (let [agt (agent 0)]
-      (send-via clojure.lang.agent/solo-executor agt + 1 1)
-      (await agt)
-      (is (= 2 (deref agt)))))
-
-  (testing "send-off"
-    (let [agt (agent 0)]
-      (send-off agt + 1 1)
-      (await agt)
-      (is (= 2 (deref agt)))))
-
-  (testing "send-via the pooled-executor"
-    (let [agt (agent 0)]
-      (send-via clojure.lang.agent/pooled-executor agt + 1 1)
-      (await agt)
-      (is (= 2 (deref agt)))))
-
-  (testing "send"
-    (let [agt (agent 0)]
-      (send agt + 1 1)
-      (await agt)
-      (is (= 2 (deref agt)))))
-
-  (testing "an agent's error is nil by default"
-    (is (nil? (agent-error (agent 0)))))
-
-  (testing "an agent's errors is nil by default"
-    (is (nil? (agent-errors (agent 0)))))
-
-  (testing "an agent's error handler is nil by default"
-    (is (nil? (error-handler (agent 0)))))
-
-  (testing "handling errors with an error handler"
-    (let [sentinel (atom false)
-          agt (agent 0 :error-handler (fn [_ _] (reset! sentinel true)))]
-      (send agt seq)
-      (await agt)
-      (is (true? (deref sentinel)))))
-
-  (testing "allows an error handler to be set after an agent is created"
-    (let [agt (agent 0)
-          handler-fn (fn [_ _])]
-      (set-error-handler! agt handler-fn)
-      (is (= handler-fn (error-handler agt)))))
-
-  (testing "await-for a period of time"
-    (let [agt (agent 0)]
-      (send agt (fn [_] (sleep 100)))
-      (is (false? (await-for 1 agt)))))
-
-  (testing "throws runtime exception if agent does not need a restart"
-    (let [agt (agent 0)]
-      (runtime-exception-is-thrown? #"Agent does not need a restart" (restart-agent agt 1))))
-
-  (testing "allows a failed agent to restart with a new state"
-    (let [agt (agent 0)]
-      (send agt (fn [_] (throw (new-runtime-exception "welp"))))
-      (sleep 100) ; ¯\_(ツ)_/¯
-      (restart-agent agt 1)
-      (is (= 1 (deref agt)))))
-
-  (testing "meta is nil when not defined"
-    (is (nil? (meta (agent "agt")))))
-
-  (testing "creates an agent with meta"
-    (let [agt (agent "agt" :meta {:foo :bar})]
-      (is (= {:foo :bar} (meta agt)))))
-
-  (testing "meta can be reset on the same object"
-    (let [agt (agent "agt" :meta {:foo :bar})
-          reset-meta-value (reset-meta! agt {:baz :bang})]
-      (is (= {:baz :bang} reset-meta-value))
-      (is (= {:baz :bang} (meta agt)))))
-
-  (testing "meta can be altered on the same object"
-    (let [agt (agent "agt" :meta {:foo :bar})
-          alter-meta-value (alter-meta! agt (fn [_ k v] {k v}) :baz :bang)]
-      (is (= {:baz :bang} alter-meta-value))
-      (is (= {:baz :bang} (meta agt)))))
-
-  (testing "get-validator will return the current validator function"
-    (let [validator-fn #(not= 3 %)
-          agt (agent 2 :validator validator-fn)]
-      (is (= validator-fn (get-validator agt)))))
-
-  (testing "get-validator is nil if a validator has not been set"
-    (is (nil? (get-validator (agent "agt")))))
-
-  (testing "set-validator! will set the current validator function"
-    (let [validator-fn #(not= 3 %)
-          agt (agent 2)]
-      (is (nil? (set-validator! agt validator-fn)))
-      (is (= validator-fn (get-validator agt)))))
-
-  )

--- a/test/defs/clojure/lang/agent_test_def.clj
+++ b/test/defs/clojure/lang/agent_test_def.clj
@@ -1,0 +1,104 @@
+(ns clojure.lang.agent-test-def)
+
+(defmacro gen-agent-test []
+  '(deftest agent-test
+     (testing "creates an agent which can be deferenced"
+       (let [agt (agent "agt")]
+         (is (= "agt" (deref agt)))))
+
+     (testing "send-via the solo-executor"
+       (let [agt (agent 0)]
+         (send-via clojure.lang.agent/solo-executor agt + 1 1)
+         (await agt)
+         (is (= 2 (deref agt)))))
+
+     (testing "send-off"
+       (let [agt (agent 0)]
+         (send-off agt + 1 1)
+         (await agt)
+         (is (= 2 (deref agt)))))
+
+     (testing "send-via the pooled-executor"
+       (let [agt (agent 0)]
+         (send-via clojure.lang.agent/pooled-executor agt + 1 1)
+         (await agt)
+         (is (= 2 (deref agt)))))
+
+     (testing "send"
+       (let [agt (agent 0)]
+         (send agt + 1 1)
+         (await agt)
+         (is (= 2 (deref agt)))))
+
+     (testing "an agent's error is nil by default"
+       (is (nil? (agent-error (agent 0)))))
+
+     (testing "an agent's errors is nil by default"
+       (is (nil? (agent-errors (agent 0)))))
+
+     (testing "an agent's error handler is nil by default"
+       (is (nil? (error-handler (agent 0)))))
+
+     (testing "handling errors with an error handler"
+       (let [sentinel (atom false)
+             agt (agent 0 :error-handler (fn [_ _] (reset! sentinel true)))]
+         (send agt seq)
+         (await agt)
+         (is (true? (deref sentinel)))))
+
+     (testing "allows an error handler to be set after an agent is created"
+       (let [agt (agent 0)
+             handler-fn (fn [_ _])]
+         (set-error-handler! agt handler-fn)
+         (is (= handler-fn (error-handler agt)))))
+
+     (testing "await-for a period of time"
+       (let [agt (agent 0)]
+         (send agt (fn [_] (sleep 100)))
+         (is (false? (await-for 1 agt)))))
+
+     (testing "throws runtime exception if agent does not need a restart"
+       (let [agt (agent 0)]
+         (runtime-exception-is-thrown? #"Agent does not need a restart" (restart-agent agt 1))))
+
+     (testing "allows a failed agent to restart with a new state"
+       (let [agt (agent 0)]
+         (send agt (fn [_] (throw (new-runtime-exception "welp"))))
+         (sleep 100) ; ¯\_(ツ)_/¯
+         (restart-agent agt 1)
+         (is (= 1 (deref agt)))))
+
+     (testing "meta is nil when not defined"
+       (is (nil? (meta (agent "agt")))))
+
+     (testing "creates an agent with meta"
+       (let [agt (agent "agt" :meta {:foo :bar})]
+         (is (= {:foo :bar} (meta agt)))))
+
+     (testing "meta can be reset on the same object"
+       (let [agt (agent "agt" :meta {:foo :bar})
+             reset-meta-value (reset-meta! agt {:baz :bang})]
+         (is (= {:baz :bang} reset-meta-value))
+         (is (= {:baz :bang} (meta agt)))))
+
+     (testing "meta can be altered on the same object"
+       (let [agt (agent "agt" :meta {:foo :bar})
+             alter-meta-value (alter-meta! agt (fn [_ k v] {k v}) :baz :bang)]
+         (is (= {:baz :bang} alter-meta-value))
+         (is (= {:baz :bang} (meta agt)))))
+
+     (testing "get-validator will return the current validator function"
+       (let [validator-fn #(not= 3 %)
+             agt (agent 2 :validator validator-fn)]
+         (is (= validator-fn (get-validator agt)))))
+
+     (testing "get-validator is nil if a validator has not been set"
+       (is (nil? (get-validator (agent "agt")))))
+
+     (testing "set-validator! will set the current validator function"
+       (let [validator-fn #(not= 3 %)
+             agt (agent 2)]
+         (is (nil? (set-validator! agt validator-fn)))
+         (is (= validator-fn (get-validator agt)))))
+
+     ))

--- a/test/gold_standard/org/clojure/lang/agent_test.clj
+++ b/test/gold_standard/org/clojure/lang/agent_test.clj
@@ -1,0 +1,19 @@
+(ns org.clojure.lang.agent-test
+  (:require [clojure.lang.agent-test-def :refer [gen-agent-test]]
+            [clojure.test                :refer :all]))
+
+(def argument-error IllegalArgumentException)
+
+(def runtime-exception RuntimeException)
+
+(defmacro new-runtime-exception [& args]
+  (list* 'new 'RuntimeException args))
+
+(defmacro runtime-exception-is-thrown? [msg & body]
+  (list 'is (list* 'thrown-with-msg? 'RuntimeException msg body)))
+
+(defmacro sleep [t]
+  `(Thread/sleep ~t))
+
+(gen-agent-test)
+


### PR DESCRIPTION
RFC

Allows tests to be run with different dependencies.

I'm not in love with this, but I think it would be a _very_ nice pattern for specification checking. It would allow us to eventually have a separate clojure.spec (a là rubyspec).

If there's a better way to manage the test definitions vs. dependencies I would love to hear it. I was thinking about trying to write some edn -> test thing but it felt like too much overhead.
