### PR TITLE
Remove defmap and introduce new deftype

### DIFF
--- a/src/clj/clojure/lang/apersistent_map.clj
+++ b/src/clj/clojure/lang/apersistent_map.clj
@@ -48,13 +48,4 @@
           (let [entry (first s)]
             (recur (assoc mp (key entry) (val entry)) (next s)))
           mp))))
-
-(defmacro defmap [type bindings & body]
-  (concat
-    (list* 'clojure.core/deftype type bindings body)
-    (-> {}
-      (platform-hash-method 'clojure.lang.apersistent-map/map-hash)
-      ;platform-show-method
-      platform-enumerable-method
-      (platform-equals-method 'clojure.lang.apersistent-map/map-equals?)
-      expand-methods)))
+ 

--- a/src/clj/clojure/lang/aseq.clj
+++ b/src/clj/clojure/lang/aseq.clj
@@ -26,3 +26,4 @@
     (-> {}
       (platform-equals-method 'clojure.lang.aseq/seq-equal?)
       expand-methods)))
+

--- a/src/clj/clojure/lang/deftype.clj
+++ b/src/clj/clojure/lang/deftype.clj
@@ -1,5 +1,6 @@
 (ns clojure.lang.deftype
-  (:refer-clojure :only [defn reduce concat cons fn let key val]))
+  (:refer-clojure :only [cond class? defmacro defn defn- reduce macroexpand-1 concat cons fn last let list* list? map key val resolve str symbol symbol? ->])
+  (:require [clojure.string :refer [split]]))
 
 (defn expand-methods [methods]
   (reduce
@@ -9,3 +10,23 @@
                 acc)))
     []
     methods))
+
+(defn- symbol->Class [resolved-symbol original-symbol]
+  (if (class? resolved-symbol)
+    (-> (str resolved-symbol)
+        (split #"\.")
+        last
+        symbol)
+    original-symbol))
+
+(defmacro deftype [t bs & body]
+  (let [b (map #(cond
+                  (symbol? %)
+                    (symbol->Class @(resolve %) %)
+                  (list? %)
+                    (macroexpand-1 %)
+                  :else
+                    %)
+                body)]
+    (list* 'clojure.core/deftype t bs b)))
+

--- a/src/clj/clojure/lang/lazy_seq.clj
+++ b/src/clj/clojure/lang/lazy_seq.clj
@@ -1,9 +1,12 @@
 (ns clojure.lang.lazy-seq
-  (:refer-clojure :only [declare defn defn- deftype let list locking loop])
-  (:require [clojure.lang.object    :as    platform-object]
-            [clojure.lang.protocols :refer [ICounted ILazySeq IMeta IObj ISeq ISeqable ISequential
-                                            -sval -seq -first -next -more]]
-            [clojure.next           :refer :all]))
+  (:refer-clojure :only [declare defn defn- let list locking loop])
+  (:require [clojure.lang.aseq        :refer [seq-equal?]]
+            [clojure.lang.deftype     :refer [deftype]]
+            [clojure.lang.equivalence :as    equiv]
+            [clojure.lang.object      :as    platform-object]
+            [clojure.lang.protocols   :refer [ICounted ILazySeq IMeta IObj ISeq ISeqable ISequential
+                                              -sval -seq -first -next -more]]
+            [clojure.next             :refer :all]))
 
 (declare make-lazy-seq)
 
@@ -69,7 +72,11 @@
   (-more [this]
     (if (nil? s)
       (list)
-      (-more (-seq this)))))
+      (-more (-seq this))))
+
+  platform-object/base-object
+  (equiv/equals-method [this other]
+    (seq-equal? this other)))
 
 (defn make-lazy-seq
   ([-fn]

--- a/src/jvm/clojure/lang/enumerable.clj
+++ b/src/jvm/clojure/lang/enumerable.clj
@@ -1,6 +1,8 @@
 (ns clojure.lang.enumerable
-  (:refer-clojure :only [deftype let reset! defn update-in fn cons list])
+  (:refer-clojure :only [defmacro deftype let reset! defn update-in fn cons list])
   (:require [clojure.next :refer [first next] :exclude [cons]]))
+
+(def base-enumerator Iterable)
 
 (deftype SeqIterator [^:unsynchronized-mutable -current-seq]
   java.util.Iterator
@@ -30,3 +32,7 @@
                        (list 'clojure.lang.enumerable/new-seq-iterator
                              (list 'clojure.next/seq 'this)))
                  old))))
+
+(defmacro enumerable-method [bindings & body]
+  `(iterator ~bindings ~@body))
+

--- a/src/jvm/clojure/lang/equivalence.clj
+++ b/src/jvm/clojure/lang/equivalence.clj
@@ -17,3 +17,7 @@
                  (list 'equals ['this 'other]
                        (list init-macro 'this 'other))
                  old))))
+
+(defmacro equals-method [bindings & body]
+  `(equals ~bindings ~@body))
+

--- a/src/jvm/clojure/lang/hash.clj
+++ b/src/jvm/clojure/lang/hash.clj
@@ -1,5 +1,5 @@
 (ns clojure.lang.hash
-  (:refer-clojure :only [extend-protocol extend-type fn defn list update-in cons])
+  (:refer-clojure :only [defmacro extend-protocol extend-type fn defn list update-in cons])
   (:require [clojure.lang.protocols :refer [IHash]])
   (:import [clojure.lang Util]))
 
@@ -23,4 +23,7 @@
 (extend-type nil
   IHash
   (-hash [this] 0))
+
+(defmacro hash-method [bindings & body]
+  `(hashCode ~bindings ~@body))
 


### PR DESCRIPTION
Our current abstract types are, unfortunately, not composable. I can't say, for instance, `(defseq (defcallable [] (call [this]) (next [this]) (rest [this]) (more [this])))`. So, instead of using "inheritance" and abstract classes I am proposing that we use composition.

Clojure's implementation of `deftype` will not resolve symbols in the class name position and will not macroexpand methods. This PR introduces a new `deftype` (for internal use only) which will do both class name resolution and method macroexpansion. This way we can introduce the indirection necessary to not rely on concrete classes (like `Object`) and concrete method names (like `equals`) and instead refer to platform specific implementations.

This will also save us from writing macros to introduce platform specific concepts to new types which was accomplished before with `expand-methods`.

This PR also only uses this new strategy for maps and will move to all types over time.